### PR TITLE
remove pytest from dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ VERSION = module.VERSION
 reqs = [
     "click",
     "cached-property",
-    "pytest",
     "scipy",
     "numpy",
     "h5py",


### PR DESCRIPTION
I didn't notice, but pytest as well as being in the extras, was also in the dependencies.
@cattabiani  @matz-e 