### PR TITLE
Introduce a new utils.Graph class

### DIFF
--- a/astrovascpy/bloodflow.py
+++ b/astrovascpy/bloodflow.py
@@ -31,7 +31,7 @@ from astrovascpy.scipy_petsc_conversions import BinaryIO2PETScVec
 from astrovascpy.scipy_petsc_conversions import PETScVec2array
 from astrovascpy.scipy_petsc_conversions import array2PETScVec
 from astrovascpy.scipy_petsc_conversions import coomatrix2PETScMat
-from astrovascpy.utils import GRAPH_HELPER
+from astrovascpy.utils import Graph
 from astrovascpy.utils import find_neighbors
 from astrovascpy.utils import mpi_mem
 from astrovascpy.utils import mpi_timer
@@ -58,7 +58,7 @@ def compute_static_laplacian(graph, blood_viscosity, with_hematocrit=True):
     """Compute the time-independent Laplacian.
 
     Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
+        graph (utils.Graph): graph containing point vasculature skeleton.
         blood_viscosity (float): plasma viscosity in g.µm^-1.s^-1
         with_hematocrit (bool): consider hematrocrit for resistance model
 
@@ -88,7 +88,7 @@ def update_static_flow_pressure(
     """Compute the time-independent pressure and flow.
 
     Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
+        graph (utils.Graph): graph containing point vasculature skeleton.
         input_flow(numpy.array): input flow for each graph node.
         blood_viscosity (float): plasma viscosity in g.µm^-1.s^-1
         base_pressure (float): minimum pressure in the output edges
@@ -113,8 +113,8 @@ def update_static_flow_pressure(
     )
 
     if MPI_RANK == 0:
-        cc_mask = GRAPH_HELPER.get_cc_mask(graph)
-        degrees = GRAPH_HELPER.get_degrees(graph)
+        cc_mask = graph.cc_mask
+        degrees = graph.degrees
         laplacian_cc = laplacian.tocsc()[cc_mask, :][:, cc_mask]
         input_flow = input_flow[cc_mask]
     else:
@@ -170,7 +170,7 @@ def set_edge_resistances(graph, blood_viscosity, with_hematocrit=True):
     """Set the edge resistances on graph.edge_properties.
 
     Args:
-        graph (vasculatureAPI.VasculatureGraph): graph containing point vasculature skeleton.
+        graph (utils.Graph): graph containing point vasculature skeleton.
         blood_viscosity (float): 1.2e-6 , standard value of the plasma viscosity (g.µm^-1.s^-1).
         with_hematocrit (bool): consider hematrocrit for resistance model.
     """
@@ -185,7 +185,7 @@ def set_endfeet_ids(graph, edge_ids, endfeet_ids):
     """Set endfeet ids to graph.edge_properties.
 
     Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
+        graph (utils.Graph): graph containing point vasculature skeleton.
         edge_ids (pandas IndexSlice): is the corresponding id for each edge.
         endfeet_ids (numpy.array): (nb_endfeet_ids,) is the corresponding endfeet ids.
 
@@ -203,7 +203,7 @@ def set_endfeet_ids(graph, edge_ids, endfeet_ids):
 def generate_endfeet(graph, endfeet_coverage, seed):
     """Generates endfeet ids on randomly selected edges
     Args:
-        graph (vasculatureAPI.PointVasculature).
+        graph (utils.Graph).
         endfeet_coverage (float): Percentage of edges connected with endfeet.
         seed (int): random number generator seed.
     """
@@ -226,7 +226,7 @@ def get_radii_at_endfeet(graph):
     """Get the radii at endfeet.
 
     Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
+        graph (utils.Graph): graph containing point vasculature skeleton.
 
     Returns:
         DataFrame: (endfeet_id, radius) pandas dataframe with endfeet_id and corresponding radius.
@@ -240,7 +240,7 @@ def get_radius_at_endfoot(graph, endfoot_id):
     """Get the radius at endfoot.
 
     Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
+        graph (utils.Graph): graph containing point vasculature skeleton.
         endfoot_id (int): is the corresponding endfoot id.
 
     Returns:
@@ -260,7 +260,7 @@ def set_radii_at_endfeet(graph, endfeet_radii):
     """Set radii at endfeet.
 
     Args:
-        graph (vasculatureAPI.PointVasculature): raph containing point vasculature skeleton.
+        graph (utils.Graph): raph containing point vasculature skeleton.
         endfeet_radii (DataFrame): (endfeet_id, radius) pandas dataframe with endfeet_id and
         the corresponding radius.
     """
@@ -271,7 +271,7 @@ def set_radius_at_endfoot(graph, endfoot_id, endfoot_radius):
     """Set radius at endfoot.
 
     Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
+        graph (utils.Graph): graph containing point vasculature skeleton.
         endfoot_id (int): is the corresponding endfoot id.
         endfoot_radius (float or numpy.array): corresponding radius.
 
@@ -296,7 +296,7 @@ def set_endfoot_id(graph, endfoot_id, section_id, segment_id, endfeet_length):  
     set the explored edges to the endfoot_id.
 
     Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
+        graph (utils.Graph): graph containing point vasculature skeleton.
         endfoot_id (int): id of the endfoot.
         segment_id (int): id of the corresponding segment.
         section_id (int): id of the corresponding section.
@@ -316,7 +316,7 @@ def get_closest_edges(args, graph):
         args[0] being segment_id (int): id of the corresponding segment,
         args[1], section_id (int): id of the corresponding section and
         args[2], endfeet_length (float): is the corresponding endfoot length in µm.
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
+        graph (utils.Graph): graph containing point vasculature skeleton.
 
     Returns:
         numpy.array: list of edges close to the original edge id.
@@ -337,7 +337,7 @@ def _depth_first_search(graph, current_edge, current_distance, visited=None):
     """Traverse graph using Depth-first search and return edge ids close to starting edge.
 
     Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
+        graph (utils.Graph): graph containing point vasculature skeleton.
         current_edge (tuple): id of the current edge to process.
         current_distance (float): left distance to be traversed.
         visited (set): list of all edges that have been visited so far.
@@ -370,7 +370,7 @@ def boundary_flows_A_based(graph, entry_nodes, input_flows):
     """Compute the boundary flows on the exit nodes based on their areas.
 
     Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
+        graph (Graph): graph containing point vasculature skeleton.
         entry_nodes (numpy.array): Ids of the entry nodes.
         input_flows (numpy.array): Flows on the entry nodes.
 
@@ -379,9 +379,9 @@ def boundary_flows_A_based(graph, entry_nodes, input_flows):
     """
 
     if graph is not None:
-
-        degrees = GRAPH_HELPER.get_degrees(graph)
-        cc_mask = GRAPH_HELPER.get_cc_mask(graph)
+        assert isinstance(graph, Graph)
+        degrees = graph.degrees
+        cc_mask = graph.cc_mask
 
         # Compute nodes of degree 1 where blood flows out
         boundary_nodes_mask = (degrees == 1) & cc_mask
@@ -407,7 +407,7 @@ def simulate_vasodilation_ou_process(graph, dt, nb_iteration, nb_iteration_noise
     """Simulate vasodilation according to the Ornstein-Uhlenbeck process.
 
     Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
+        graph (Graph): graph containing point vasculature skeleton.
         dt (float): time-step.
         nb_iteration (int): number of iteration.
         nb_iteration_noise (int): number of time steps with non-zero noise.
@@ -433,6 +433,7 @@ def simulate_vasodilation_ou_process(graph, dt, nb_iteration, nb_iteration_noise
     kappa_a, sigma_a = None, None
 
     if graph is not None:
+        assert isinstance(graph, Graph)
         ge = graph.edge_properties["radius_origin"]
         # calibrate kappa for capillaries
         # We calibrate only for the first radius.
@@ -531,7 +532,7 @@ def simulate_ou_process(
     """Update value according to the reflected Ornstein-Ulenbeck.
 
     Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
+        graph (utils.Graph): graph containing point vasculature skeleton.
         params (dict): general parameters for vasculature.
         entry_nodes (numpy.array:): (nb_entry_nodes,) ids of entry_nodes.
         simulation_time (float): total time of the simulation, in seconds.
@@ -613,7 +614,7 @@ def construct_static_incidence_matrix(graph):
     """Compute the oriented graph opposite and transposed incidence matrix for static computations.
 
     Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
+        graph (utils.Graph): graph containing point vasculature skeleton.
 
     Returns:
         scipy.sparse.csc_matrix: returns the opposite and transposed incidence matrix of graph
@@ -639,7 +640,6 @@ def _solve_linear(laplacian, input_flow):
     """
 
     if MPI_RANK == 0:
-
         if sp.issparse(input_flow):
             input_flow = input_flow.toarray()
 

--- a/astrovascpy/io.py
+++ b/astrovascpy/io.py
@@ -20,7 +20,7 @@ from vascpy import PointVasculature
 from vascpy import SectionVasculature
 
 from astrovascpy.exceptions import BloodFlowError
-from astrovascpy.utils import set_edge_data
+from astrovascpy.utils import Graph
 
 MPI_COMM = mpi.COMM_WORLD
 MPI_RANK = MPI_COMM.Get_rank()
@@ -33,17 +33,17 @@ def load_graph(filename):
         filename (str): vasculature dataset.
 
     Returns:
-        vasculatureAPI.PointVasculature: graph containing point vasculature skeleton.
+        utils.Graph: graph containing point vasculature skeleton.
 
     Raises:
         BloodFlowError: if the file object identified by filename is not in h5 format.
     """
     if Path(filename).suffix == ".h5":
-        graph = SectionVasculature.load(filename).as_point_graph()
+        pv = SectionVasculature.load(filename).as_point_graph()
+        graph = Graph.from_point_vasculature(pv)
         graph.edge_properties.index = pd.MultiIndex.from_frame(
             graph.edge_properties.loc[:, ["section_id", "segment_id"]]
         )
-        set_edge_data(graph)
         return graph
     raise BloodFlowError("File object type identified by filename is not supported")
 
@@ -56,13 +56,14 @@ def load_graph_from_bin(filename, is_cc=False):
         save_cc (bool): if True the graph is assumed to be fully connected and
         the computation of the main connected component is skipped
     Returns:
-        vasculatureAPI.PointVasculature: graph containing point vasculature skeleton.
+        utils.Graph: graph containing point vasculature skeleton.
     """
     if MPI_RANK == 0:
         if os.path.exists(filename):
             print("Loading graph from binary file using pickle", flush=True)
             filehandler = open(filename, "rb")
-            graph = pickle.load(filehandler)
+            pv = pickle.load(filehandler)
+            graph = Graph.from_point_vasculature(pv)
         else:
             raise BloodFlowError("Graph file not found")
         return graph
@@ -78,13 +79,13 @@ def load_graph_from_h5(filename, is_cc=False):
         save_cc (bool): if True the graph is assumed to be fully connected and
         the computation of the main connected component is skipped
     Returns:
-        vasculatureAPI.PointVasculature: graph containing point vasculature skeleton.
+        utils.Graph: graph containing point vasculature skeleton.
     """
     if MPI_RANK == 0:
         if os.path.exists(filename):
             print("Loading sonata graph using PointVasculature.load_sonata", flush=True)
-            graph = PointVasculature.load_sonata(filename)
-            set_edge_data(graph)
+            pv = PointVasculature.load_sonata(filename)
+            graph = Graph.from_point_vasculature(pv)
         else:
             raise BloodFlowError("Graph file not found")
         return graph
@@ -103,7 +104,7 @@ def load_graph_from_csv(node_filename, edge_filename, is_cc=False):
         save_cc (bool): if True the graph is assumed to be fully connected and
         the computation of the main connected component is skipped
     Returns:
-        vasculatureAPI.PointVasculature: graph containing point vasculature skeleton.
+        utils.Graph: graph containing point vasculature skeleton.
     """
     if MPI_RANK == 0:
         print("Loading csv dataset using pandas", flush=True)
@@ -115,11 +116,8 @@ def load_graph_from_csv(node_filename, edge_filename, is_cc=False):
             if col not in graph_edges.columns:
                 raise BloodFlowError(f"Missing {col} in columns")
 
-        graph = PointVasculature(graph_nodes, graph_edges)
-
-        if "endfeet_id" not in graph_edges.columns:
-            set_edge_data(graph)
-
+        pv = PointVasculature(graph_nodes, graph_edges)
+        graph = Graph.from_point_vasculature(pv)
         return graph
     else:
         return None

--- a/astrovascpy/utils.py
+++ b/astrovascpy/utils.py
@@ -15,16 +15,17 @@ import sys
 import time
 from collections.abc import Iterable
 from contextlib import contextmanager
+from functools import cached_property
 
 import networkx as nx
 import numpy as np
 import pandas as pd
 import psutil
 import scipy as scp
+import vascpy
 from mpi4py import MPI
 from scipy.signal import find_peaks_cwt
 from scipy.sparse.csgraph import connected_components
-from vascpy import PointVasculature
 
 from astrovascpy.exceptions import BloodFlowError
 
@@ -41,6 +42,97 @@ L = logging.getLogger(__name__)
 L.addHandler(console_handler)
 
 MPI_RANK = MPI.COMM_WORLD.Get_rank()
+
+
+class Graph(vascpy.PointVasculature):
+    """Wrapper on top of a vascpy.PointVasculator providing
+    additional graph-related capabilities
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if "endfeet_id" not in self._edge_properties.columns:
+            self._set_edge_data()
+
+    @classmethod
+    def from_point_vasculature(cls, point_vasculature):
+        """Instantiate a Graph from a PointVasculature instance
+
+        Args:
+          graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
+        """
+        return cls(point_vasculature._node_properties, point_vasculature._edge_properties)
+
+    @cached_property
+    def cc_mask(self):
+        """
+        Returns: ids (numpy.array) of the main connected component.
+
+        Computation is made once, next calls for this property
+        will returned the cached result.
+
+        """
+        _, labels = connected_components(
+            self.adjacency_matrix.as_sparse(), directed=False, return_labels=True
+        )
+        largest_cc_label = np.argmax(np.unique(labels, return_counts=True)[1])
+        return labels == largest_cc_label
+
+    @cached_property
+    def degrees(self):
+        """
+        Returns: degrees (numpy.array) of each node
+
+        Computation is made once, next calls for this property
+        will returned the cached result.
+        """
+        return super().degrees
+
+    def get_main_connected_component(self):
+        """Build a graph with only the largest Connected Component (CC).
+
+        Returns: largest CC point graph (Graph)
+        """
+        _, labels = connected_components(
+            self.adjacency_matrix.as_sparse(), directed=False, return_labels=True
+        )
+        largest_cc_label = np.argmax(np.unique(labels, return_counts=True)[1])
+        to_keep_labels = labels == largest_cc_label
+        graph_point = self.node_properties.loc[to_keep_labels]
+        index = graph_point.index
+        graph_edge = self.edge_properties[
+            (self.edge_properties["start_node"].isin(index))
+            | (self.edge_properties["end_node"].isin(index))
+        ]
+        return Graph(graph_point, graph_edge)
+
+    def _set_edge_data(self):
+        """Set lengths, radii, and endefeet_id of edges."""
+        lengths, radii, volume = self._compute_edge_data()
+        self.edge_properties["length"] = lengths
+        self.edge_properties["radius"] = radii
+        self.edge_properties["radius_origin"] = radii
+        self.edge_properties["endfeet_id"] = np.full(radii.shape, -1, dtype=int)
+        self.edge_properties["volume"] = volume
+
+    def _compute_edge_data(self):
+        """Compute the length, radius and volume of each edge.
+
+        Args:
+            graph (Graph): graph containing point vasculature skeleton.
+
+        Returns:
+            numpy.array: (nb_edges, ) radii of each edge (units: µm).
+            numpy.array: (nb_edges, ) lengths of each edge (units: µm).
+            numpy.array: (nb_edges, ) volume of each edge (units: µm^3).
+        """
+        positions = self.points
+        beg_nodes, end_nodes = self.edges.T
+        edge_lengths = np.linalg.norm(positions[end_nodes] - positions[beg_nodes], axis=1)
+        node_radii = 0.5 * self.diameters
+        edge_radii = 0.5 * (node_radii[beg_nodes] + node_radii[end_nodes])
+        edge_volume = edge_lengths * np.power(edge_radii, 2) * np.pi
+        return edge_lengths, edge_radii, edge_volume
 
 
 def find_neighbors(graph, section_id, segment_id):
@@ -84,29 +176,6 @@ def find_degrees_of_neighbors(graph, node_id):
     connected_nodes = set(graph.edge_properties.start_node[neighbors_mask].to_list())
     connected_nodes |= set(graph.edge_properties.end_node[neighbors_mask].to_list())
     return neighbors_mask, connected_nodes, graph.degrees[np.array(list(connected_nodes))]
-
-
-def get_main_connected_component(graph):
-    """Return a graph with only the largest Connected Component (CC).
-
-    Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
-
-    Returns:
-        vasculatureAPI.PointVasculature: largest CC point graph.
-    """
-    _, labels = connected_components(
-        graph.adjacency_matrix.as_sparse(), directed=False, return_labels=True
-    )
-    largest_cc_label = np.argmax(np.unique(labels, return_counts=True)[1])
-    to_keep_labels = labels == largest_cc_label
-    graph_point = graph.node_properties.loc[to_keep_labels]
-    index = graph_point.index
-    graph_edge = graph.edge_properties[
-        (graph.edge_properties["start_node"].isin(index))
-        | (graph.edge_properties["end_node"].isin(index))
-    ]
-    return PointVasculature(graph_point, graph_edge)
 
 
 def reduce_to_largest_cc(graph):  # pragma: no cover
@@ -155,7 +224,7 @@ def get_subset(graph, iterations=100, starting_nodes_id=None):
         starting_nodes_id (int): start node id.
 
     Returns:
-        vasculatureAPI.PointVasculature: reduced to the largest cc point graph.
+        Graph: reduced to the largest cc point graph.
     """
     if starting_nodes_id is None:
         starting_nodes_id = graph.node_properties.loc[graph.degrees == 1, "diameter"].idxmax()
@@ -186,48 +255,14 @@ def reduce_graph(graph, to_keep_labels):
     new_edge_properties = new_edge_properties.reset_index().drop(columns=["index"])
     new_node_properties.index.name = "index"
     new_edge_properties.index.name = "index"
-    return PointVasculature(new_node_properties, new_edge_properties)
-
-
-def compute_edge_data(graph):
-    """Compute the length, radius and volume of each edge.
-
-    Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
-
-    Returns:
-        numpy.array: (nb_edges, ) radii of each edge (units: µm).
-        numpy.array: (nb_edges, ) lengths of each edge (units: µm).
-        numpy.array: (nb_edges, ) volume of each edge (units: µm^3).
-    """
-    positions = graph.points
-    beg_nodes, end_nodes = graph.edges.T
-    edge_lengths = np.linalg.norm(positions[end_nodes] - positions[beg_nodes], axis=1)
-    node_radii = 0.5 * graph.diameters
-    edge_radii = 0.5 * (node_radii[beg_nodes] + node_radii[end_nodes])
-    edge_volume = edge_lengths * np.power(edge_radii, 2) * np.pi
-    return edge_lengths, edge_radii, edge_volume
-
-
-def set_edge_data(graph):
-    """Set lengths, radii, and endefeet_id of edges.
-
-    Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
-    """
-    lengths, radii, volume = compute_edge_data(graph)
-    graph.edge_properties["length"] = lengths
-    graph.edge_properties["radius"] = radii
-    graph.edge_properties["radius_origin"] = radii
-    graph.edge_properties["endfeet_id"] = np.full(radii.shape, -1, dtype=int)
-    graph.edge_properties["volume"] = volume
+    return Graph(new_node_properties, new_edge_properties)
 
 
 def create_entry_largest_nodes(graph, params):
     """Get largest nodes of degree 1 for input in the largest connected components.
 
     Args:
-        graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
+        graph (Graph): graph containing point vasculature skeleton.
         params (dict): general parameters for vasculature.
 
     Returns:
@@ -237,6 +272,7 @@ def create_entry_largest_nodes(graph, params):
         BloodFlowError: if n_nodes <= 0 or if vasc_axis is not 0, 1 or 2.
     """
     if graph is not None:
+        assert isinstance(graph, Graph)
         if (
             "max_nb_inputs" not in params
             or "depth_ratio" not in params
@@ -258,8 +294,8 @@ def create_entry_largest_nodes(graph, params):
             depth_ratio = 1.0
             L.warning("The depth_ratio must be <= 1. Taking depth_ratio = 1.")
 
-        degrees = GRAPH_HELPER.get_degrees(graph)
-        cc_mask = GRAPH_HELPER.get_cc_mask(graph)
+        degrees = graph.degrees
+        cc_mask = graph.cc_mask
 
         positions = graph.points[cc_mask]
         max_position = np.max(positions[:, vasc_axis])
@@ -435,7 +471,7 @@ def convert_from_networkx(nx_graph):
         nx_graph (networkx graph): input networkx graph
 
     Returns:
-        vascpy.PointVasculature: graph containing point vasculature skeleton.
+        Graph: graph containing point vasculature skeleton.
     """
     node_properties = pd.DataFrame(columns=["x", "y", "z", "diameter"])
     for i in nx_graph:
@@ -455,7 +491,7 @@ def convert_from_networkx(nx_graph):
         edge_properties.loc[i, "type"] = nx_graph[e][v].get("type", 0)
     edge_properties["start_node"] = pd.to_numeric(edge_properties["start_node"])
     edge_properties["end_node"] = pd.to_numeric(edge_properties["end_node"])
-    return PointVasculature(node_properties, edge_properties)
+    return Graph(node_properties, edge_properties)
 
 
 def convert_to_temporal(data, frequencies, times):  # pragma: no cover
@@ -692,68 +728,3 @@ def create_input_speed(T, step, A=1, f=1, C=0, read_from_file=None):
         speed = C + A * np.sin(2 * np.pi * f * time)
 
     return speed
-
-
-class GRAPH_HELPER:
-    """This class helps to compute and store
-    - cc_mask: mask for the main connected component of the graph
-    - degrees: array containing the degree of each node
-    """
-
-    _cc_mask = None
-    _degrees = None
-
-    @staticmethod
-    def reset():
-        """Set cc_mask and degrees to None"""
-        GRAPH_HELPER._cc_mask = None
-        GRAPH_HELPER._degrees = None
-
-    @staticmethod
-    def compute_cc_mask(graph):
-        """
-        Args:
-            graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
-        Returns:
-            cc_mask (numpy.array): ids of the main connected component
-        """
-        _, labels = connected_components(
-            graph.adjacency_matrix.as_sparse(), directed=False, return_labels=True
-        )
-        largest_cc_label = np.argmax(np.unique(labels, return_counts=True)[1])
-        return labels == largest_cc_label
-
-    @staticmethod
-    def compute_degrees(graph):
-        """Compute degrees of each node
-        Args:
-            graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
-        Returns:
-            degrees (numpy.array): degrees of each node
-        """
-        return graph.degrees
-
-    @staticmethod
-    def get_cc_mask(graph):
-        """
-        Args:
-            graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
-        Returns:
-            cc_mask (numpy.array): ids of the main connected component
-        """
-        if GRAPH_HELPER._cc_mask is None:
-            GRAPH_HELPER._cc_mask = GRAPH_HELPER.compute_cc_mask(graph)
-
-        return GRAPH_HELPER._cc_mask
-
-    @staticmethod
-    def get_degrees(graph):
-        """
-        Args:
-            graph (vasculatureAPI.PointVasculature): graph containing point vasculature skeleton.
-        Returns:
-            degrees (numpy.array): degrees of each node
-        """
-        if GRAPH_HELPER._degrees is None:
-            GRAPH_HELPER._degrees = GRAPH_HELPER.compute_degrees(graph)
-        return GRAPH_HELPER._degrees

--- a/tests/test_bloodflow.py
+++ b/tests/test_bloodflow.py
@@ -7,7 +7,6 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from scipy import sparse as sp
-from vascpy import PointVasculature
 
 from astrovascpy import bloodflow as tested
 from astrovascpy import utils
@@ -40,10 +39,9 @@ def test_compute_edge_resistances():
 
 
 def test_set_edge_resistances(point_properties, edge_properties):
-    graph = PointVasculature(point_properties, edge_properties)
+    graph = utils.Graph(point_properties, edge_properties)
     radii = np.array([1, 1.25])
     resistances = tested.compute_edge_resistances(radii, blood_viscosity=1.2e-6)
-    utils.set_edge_data(graph)
     tested.set_edge_resistances(graph, blood_viscosity=1.2e-6, with_hematocrit=True)
     npt.assert_allclose(resistances, graph.edge_properties["resistances"])
     with pytest.raises(BloodFlowError):
@@ -53,7 +51,7 @@ def test_set_edge_resistances(point_properties, edge_properties):
 
 
 def test_set_endfeet_ids(point_properties, edge_properties, caplog):
-    graph = PointVasculature(point_properties, edge_properties)
+    graph = utils.Graph(point_properties, edge_properties)
     graph.edge_properties["endfeet_id"] = [np.nan, np.nan]
     edge_ids = [(0, 1)]
     endfeet_ids = [1]
@@ -79,8 +77,7 @@ def test_get_radii_at_endfeet(point_properties, edge_properties):
     """Verifying that the function returns a list of pairs (endfeet, radii),
     where endfeet_id are different from -1
     """
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = utils.Graph(point_properties, edge_properties)
     edge_ids = [(0, 1)]  # (section, segment)
     endfeet_ids = [2]
     tested.set_endfeet_ids(graph, edge_ids, endfeet_ids)
@@ -91,8 +88,7 @@ def test_get_radii_at_endfeet(point_properties, edge_properties):
 
 
 def test_get_radius_at_endfoot(point_properties, edge_properties):
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = utils.Graph(point_properties, edge_properties)
     endfoot_id = 1
     section_id = 0
     segment_id = 0
@@ -110,8 +106,7 @@ def test_get_radius_at_endfoot(point_properties, edge_properties):
 
 def test_set_radii_at_endfeet(point_properties, edge_properties):
     """Verify setting of radii where there are endfeet."""
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = utils.Graph(point_properties, edge_properties)
     edge_ids = [(0, 1)]
     endfeet_ids = [2]
     tested.set_endfeet_ids(graph, edge_ids, endfeet_ids)
@@ -123,8 +118,7 @@ def test_set_radii_at_endfeet(point_properties, edge_properties):
 
 
 def test_set_radius_at_endfoot(point_properties, edge_properties):
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = utils.Graph(point_properties, edge_properties)
     section_id = 0
     segment_id = 0
     endfeet_length = 1
@@ -140,8 +134,7 @@ def test_set_radius_at_endfoot(point_properties, edge_properties):
 
 
 def test_set_endfoot_id(point_properties, edge_properties, caplog):
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = utils.Graph(point_properties, edge_properties)
     section_id = 0
     segment_id = 0
     endfeet_id = 1
@@ -173,8 +166,7 @@ def test_set_endfoot_id(point_properties, edge_properties, caplog):
 
 
 def test_get_closest_edges(point_properties, edge_properties, caplog):
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = utils.Graph(point_properties, edge_properties)
 
     (section_id, segment_id) = (0, 0)
     endfeet_length = -1
@@ -194,8 +186,7 @@ def test_get_closest_edges(point_properties, edge_properties, caplog):
 
 
 def test_simulate_vasodilation_ou_process(point_properties, edge_properties):
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = utils.Graph(point_properties, edge_properties)
     dt = 0.01
     nb_iteration = 100
     nb_iteration_noise = 2
@@ -231,8 +222,7 @@ def test_simulate_vasodilation_ou_process(point_properties, edge_properties):
 
 
 def test_simulate_ou_process(point_properties, edge_properties):
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = utils.Graph(point_properties, edge_properties)
 
     dt = 0.01
     nb_iteration = 100
@@ -285,8 +275,7 @@ def test_depth_first_search():
             names=["section_id", "segment_id"],
         ),
     )
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = utils.Graph(point_properties, edge_properties)
     current_edge = (0, 2)
     current_distance = 0.5
     results = tested._depth_first_search(graph, current_edge, current_distance)
@@ -320,8 +309,7 @@ def test_compute_static_laplacian():
             names=["section_id", "segment_id"],
         ),
     )
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = utils.Graph(point_properties, edge_properties)
 
     laplacian = tested.compute_static_laplacian(graph, blood_viscosity=1.2e-6).toarray()
 
@@ -418,11 +406,9 @@ def test_update_static_flow_pressure():
             names=["section_id", "segment_id"],
         ),
     )
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = utils.Graph(point_properties, edge_properties)
     entry_nodes = [0]
     input_flow = len(entry_nodes) * [1.0]
-    utils.GRAPH_HELPER.reset()
     boundary_flow = tested.boundary_flows_A_based(graph, entry_nodes, input_flow)
     tested.update_static_flow_pressure(
         graph, boundary_flow, blood_viscosity=1.2e-6, base_pressure=1.33e-3, with_hematocrit=True
@@ -449,7 +435,8 @@ def test_total_flow_conservation_in_graph():
     TEST_DIR = Path(__file__).resolve().parent.parent
     graph_path_cc = TEST_DIR / "examples/data/graphs_folder/toy_graph.bin"
     filehandler = open(graph_path_cc, "rb")
-    graph = pickle.load(filehandler)
+    pv = pickle.load(filehandler)
+    graph = utils.Graph.from_point_vasculature(pv)
 
     entry_nodes = [123, 144, 499]
     input_flows = [1] * len(entry_nodes)
@@ -463,7 +450,6 @@ def test_total_flow_conservation_in_graph():
     transp_incidence = tested.construct_static_incidence_matrix(graph)
     incidence = transp_incidence.T
 
-    utils.GRAPH_HELPER.reset()
     boundary_flows = tested.boundary_flows_A_based(graph, entry_nodes, input_flows)
 
     npt.assert_allclose(
@@ -531,13 +517,11 @@ def test_conservation_flow():
             names=["section_id", "segment_id"],
         ),
     )
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = utils.Graph(point_properties, edge_properties)
 
     entry_nodes = [0]
     input_flow = len(entry_nodes) * [1.0]
 
-    utils.GRAPH_HELPER.reset()
     boundary_flow = tested.boundary_flows_A_based(graph, entry_nodes, input_flow)
 
     tested.update_static_flow_pressure(
@@ -552,7 +536,7 @@ def test_conservation_flow():
 
 
 def test_static_construct_incidence_matrix(point_properties, edge_properties):
-    graph = PointVasculature(point_properties, edge_properties)
+    graph = utils.Graph(point_properties, edge_properties)
     npt.assert_allclose(
         tested.construct_static_incidence_matrix(graph).toarray(),
         np.array([[1, -1, 0], [0, 1, -1]]),
@@ -560,12 +544,10 @@ def test_static_construct_incidence_matrix(point_properties, edge_properties):
 
 
 def test_solve_linear(point_properties, edge_properties):
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = utils.Graph(point_properties, edge_properties)
     graph.edge_properties["radius"] = [1, 1.25]
     entry_nodes = [0]
     input_flow = [1.0]
-    utils.GRAPH_HELPER.reset()
     boundary_flow = tested.boundary_flows_A_based(graph, entry_nodes, input_flow)
     adjacency = sp.csr_matrix(
         (graph.n_edges * [1.0], (graph.edges[:, 0], graph.edges[:, 1])),
@@ -584,10 +566,8 @@ def test_solve_linear(point_properties, edge_properties):
 
 
 def test_boundary_flows_A_based(point_properties, edge_properties):
-    graph = PointVasculature(point_properties, edge_properties)
+    graph = utils.Graph(point_properties, edge_properties)
     graph.edge_properties["radius"] = [1, 1.25]
-    utils.set_edge_data(graph)
 
-    utils.GRAPH_HELPER.reset()
     boundary_flow = tested.boundary_flows_A_based(graph, [0], [1])
     npt.assert_allclose(boundary_flow, np.array([1.0, 0.0, -1.0]), rtol=2e-6)

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -5,7 +5,7 @@ import pandas as pd
 from vascpy import PointVasculature
 
 from astrovascpy import bloodflow as tested
-from astrovascpy import utils
+from astrovascpy.utils import Graph
 
 L = logging.getLogger(__name__)
 
@@ -30,11 +30,9 @@ def test_simple_graph():
             names=["section_id", "segment_id"],
         ),
     )
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = Graph(point_properties, edge_properties)
     entry_nodes = [0]
     input_flow = [1.0]
-    utils.GRAPH_HELPER.reset()
     boundary_flow = tested.boundary_flows_A_based(graph, entry_nodes, input_flow)
     blood_viscosity = 0.1
     tested.update_static_flow_pressure(
@@ -109,11 +107,9 @@ def test_bifurcation():
             names=["section_id", "segment_id"],
         ),
     )
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = Graph(point_properties, edge_properties)
     entry_nodes = [0]
     input_flow = [1.0]
-    utils.GRAPH_HELPER.reset()
     boundary_flow = tested.boundary_flows_A_based(graph, entry_nodes, input_flow)
     blood_viscosity = 0.1
     tested.update_static_flow_pressure(
@@ -173,11 +169,9 @@ def test_loop():
         ),
     )
 
-    graph = PointVasculature(point_properties, edge_properties)
-    utils.set_edge_data(graph)
+    graph = Graph(point_properties, edge_properties)
     entry_nodes = [0]
     input_flow = [1.0]
-    utils.GRAPH_HELPER.reset()
     boundary_flow = tested.boundary_flows_A_based(graph, entry_nodes, input_flow)
     blood_viscosity = 0.1
     tested.update_static_flow_pressure(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,8 +59,7 @@ def test_find_degrees_of_neighbors(point_properties, edge_properties):
 
 
 def test_create_entry_largest_nodes(point_properties, edge_properties, caplog):
-    graph = PointVasculature(point_properties, edge_properties)
-    test_module.GRAPH_HELPER.reset()
+    graph = test_module.Graph(point_properties, edge_properties)
     params = {
         "max_nb_inputs": 1,
         "depth_ratio": 1,
@@ -131,8 +130,8 @@ def test_get_large_nodes(point_properties, edge_properties, caplog):
 
 def test_compute_edge_data(point_properties, edge_properties):
     # length = [2, 2], radii  = [1, 1.25]
-    graph = PointVasculature(point_properties, edge_properties)
-    edge_lengths, edge_radii, edge_volume = test_module.compute_edge_data(graph)
+    graph = test_module.Graph(point_properties, edge_properties)
+    edge_lengths, edge_radii, edge_volume = graph._compute_edge_data()
     npt.assert_array_equal(edge_lengths, np.array(np.sqrt([2, 2])))
     npt.assert_array_equal(edge_radii, np.array([1, 1.25]))
     npt.assert_array_equal(
@@ -141,12 +140,12 @@ def test_compute_edge_data(point_properties, edge_properties):
 
 
 def test_set_edge_data(point_properties, edge_properties):
-    graph = PointVasculature(point_properties, edge_properties)
-    lengths, radii, volume = test_module.compute_edge_data(graph)
-    test_module.set_edge_data(graph)
-    npt.assert_allclose(lengths, graph.edge_properties["length"])
-    npt.assert_allclose(radii, graph.edge_properties["radius"])
-    npt.assert_allclose(volume, graph.edge_properties["volume"])
+    graph = test_module.Graph(point_properties, edge_properties)
+    npt.assert_allclose(np.array(np.sqrt([2, 2])), graph.edge_properties.length)
+    npt.assert_allclose(np.array([1, 1.25]), graph.edge_properties.radius)
+    npt.assert_allclose(
+        np.array([np.sqrt(2) * np.pi, 1.25**2 * np.sqrt(2) * np.pi]), graph.edge_properties.volume
+    )
 
 
 def test_is_iterable():


### PR DESCRIPTION
This new class intends to replace the usage of vascpy.PointVasculature instances in the code and get rid of the `GRAPH_HELPER` class whose API was inconvenient, and its cache implementation dangerous.

An instance of `utils.Graph` is a `vascpy.PointVasculature` but with additional methods and cached properties related to graph computation

`utils.Graph` constructor also sets its edge data so that there is no need to call it explicitely like it was done for `vascpy.PointVasculature`.