### PR TITLE
sliced_ids considers all nodes, not only cc nodes

### DIFF
--- a/astrovascpy/utils.py
+++ b/astrovascpy/utils.py
@@ -300,7 +300,9 @@ def create_entry_largest_nodes(graph, params):
         max_position = np.max(positions[:, vasc_axis])
         min_position = np.min(positions[:, vasc_axis])
         depth_max = max_position - (max_position - min_position) * depth_ratio
-        sliced_ids = np.where(cc_mask & (degrees == 1) & (positions[:, vasc_axis] >= depth_max))[0]
+        sliced_ids = np.where(cc_mask & (degrees == 1) & (graph.points[:, vasc_axis] >= depth_max))[
+            0
+        ]
         if sliced_ids.size == 0:
             raise BloodFlowError("Found zero nodes matching our conditions.")
         if sliced_ids.size < n_nodes:


### PR DESCRIPTION
The problem is that we were considering only the nodes in the main connected component.
`positions = graph.points[cc_mask]`

