### PR TITLE
New function distribute_array for np arrays

### DIFF
--- a/astrovascpy/bloodflow.py
+++ b/astrovascpy/bloodflow.py
@@ -324,7 +324,7 @@ def get_closest_edges(args, graph):
         graph (utils.Graph): graph containing point vasculature skeleton.
 
     Returns:
-        numpy.array: list of edges close to the original edge id.
+        np.ndarray: list of edges close to the original edge id.
 
     Raises:
         BloodFlowError: if endfoot_id does not correspond to a real endfoot id in the graph.
@@ -348,7 +348,7 @@ def _depth_first_search(graph, current_edge, current_distance, visited=None):
         visited (set): list of all edges that have been visited so far.
 
     Returns:
-        numpy.array: list of edges close to the original edge id.
+        np.ndarray: list of edges close to the original edge id.
     """
     if visited is None:
         visited = set()
@@ -382,7 +382,7 @@ def boundary_flows_A_based(
         input_flows (numpy.array): Flows on the entry nodes.
 
     Returns:
-        np.array: boundary flow vector for every node in the graph.
+        np.ndarray: boundary flow vector for every node in the graph.
 
     Concerns: This function is part of the public API. Any change of signature
     or functional behavior may be done thoroughly.
@@ -426,7 +426,7 @@ def simulate_vasodilation_ou_process(graph, dt, nb_iteration, nb_iteration_noise
 
 
     Returns:
-        np.array: (endfeet_id, time-step, nb_of_edge_per_endfoot) array where each edge
+        np.ndarray: (endfeet_id, time-step, nb_of_edge_per_endfoot) array where each edge
         is linked to the endfoot located at the edge's position.
     """
     radii_at_endfeet = []  # matrix: rows = number of radii, columns = time points
@@ -546,9 +546,10 @@ def simulate_ou_process(
         params (dict): general parameters for vasculature.
 
     Returns:
-        numpy.array: (nb_iteration, n_edges) flow values at each time-step for each edge,
-        numpy.array: (nb_iteration, n_nodes) pressure values at each time-step for each edge,
-        numpy.array: (nb_iteration, n_edges) radius values at each time-step for each edge.
+        tuple of 3 elements:
+        - np.ndarray: (nb_iteration, n_edges) flow values at each time-step for each edge,
+        - np.ndarray: (nb_iteration, n_nodes) pressure values at each time-step for each edge,
+        - np.ndarray: (nb_iteration, n_edges) radius values at each time-step for each edge.
     """
 
     BLOOD_VISCOSITY = params["blood_viscosity"]

--- a/astrovascpy/bloodflow.py
+++ b/astrovascpy/bloodflow.py
@@ -478,8 +478,8 @@ def simulate_vasodilation_ou_process(graph, dt, nb_iteration, nb_iteration_noise
         endfeet_id = graph.edge_properties.loc[:, "endfeet_id"].to_numpy()
 
     # Distribute vectors across MPI ranks
-    radius_origin = distribute_array(radius_origin if MPI_RANK == 0 else [])
-    endfeet_id = distribute_array(endfeet_id if MPI_RANK == 0 else [])
+    radius_origin = distribute_array(radius_origin if MPI_RANK == 0 else None)
+    endfeet_id = distribute_array(endfeet_id if MPI_RANK == 0 else None)
 
     seed = 1
     for radius_origin_, endfeet_id_ in zip(radius_origin, endfeet_id):

--- a/astrovascpy/scipy_petsc_conversions.py
+++ b/astrovascpy/scipy_petsc_conversions.py
@@ -247,9 +247,10 @@ def _distribute_array_helper(v, array_type=None):
                     If None, it keeps the same type as v.
 
     Returns:
-        numpy.array: distributed array on all procs
-        petsc4py.PETSc.Vec: distributed array on all procs.
-                            All entries are initialized to zero.
+        tuple of 2 elements:
+        - numpy.ndarray: distributed array on all processors
+        - petsc4py.PETSc.Vec: distributed array on all processors.
+                              All entries are initialized to zero.
     """
 
     if MPI_RANK == 0:
@@ -303,7 +304,7 @@ def distribute_array(v, array_type=None):
                     If None, it keeps the same type as v.
 
     Returns:
-        numpy.array: distributed array on all procs
+        numpy.ndarray: distributed array on all processors
     """
 
     vloc, x = _distribute_array_helper(v, array_type=array_type)

--- a/astrovascpy/scipy_petsc_conversions.py
+++ b/astrovascpy/scipy_petsc_conversions.py
@@ -238,17 +238,18 @@ def coomatrix2PETScMat(L):
 
 def _distribute_array_helper(v, array_type=None):
     """
-    Distributes a numpy array on rank 0 to all ranks using PETSc automatic
-    distribution routine.
+    Scatter a NumPy array from rank 0 to all ranks using PETSc automatic
+    chunk selection routine.
 
     Args:
-        v: numpy array on rank 0, None (or whatever) on other ranks
+        v: NumPy array on rank 0, None (or whatever) on other ranks
         array_type: set the type of the distributed array
                     If None, it keeps the same type as v.
 
     Returns:
-        numpy array distributed on all procs
-        PETSc.Vec distributed array. All values set to zero.
+        numpy.array: distributed array on all procs
+        petsc4py.PETSc.Vec: distributed array on all procs. 
+                            All entries are initialized to zero.
     """
 
     if MPI_RANK == 0:
@@ -293,16 +294,16 @@ def _distribute_array_helper(v, array_type=None):
 
 def distribute_array(v, array_type=None):
     """
-    Distributes a numpy array on rank 0 to all ranks using PETSc automatic
-    distribution routine.
+    Scatter a NumPy array from rank 0 to all ranks using PETSc automatic
+    chunk selection routine.
 
     Args:
-        v: numpy array on rank 0, None (or whatever) on other ranks
+        v: NumPy array on rank 0, None (or whatever) on other ranks
         array_type: set the type of the distributed array
                     If None, it keeps the same type as v.
 
     Returns:
-        numpy array distributed on all procs
+        numpy.array: distributed array on all procs
     """
 
     vloc, x = _distribute_array_helper(v, array_type=array_type)
@@ -317,10 +318,10 @@ def array2PETScVec(v):
     to a distributed PETSc Vec
 
     Args:
-        v: numpy array on proc 0, None (or whatever) on other proc
+        v: NumPy array on proc 0, None (or whatever) on other proc
 
     Returns:
-        PETSc Vec distributed on all procs
+        petsc4py.PETSc.Vec: distributed array on all procs. 
     """
 
     vloc, x = _distribute_array_helper(v, array_type=PETSc.ScalarType)
@@ -338,7 +339,7 @@ def PETScVec2array(x, rank=0):
         rank: rank receiving the numpy array
 
     Returns:
-        numpy array on proc 0
+        NumPy array on proc 0
     """
 
     vloc = x.getArray()

--- a/astrovascpy/scipy_petsc_conversions.py
+++ b/astrovascpy/scipy_petsc_conversions.py
@@ -236,27 +236,35 @@ def coomatrix2PETScMat(L):
     return A
 
 
-def array2PETScVec(v):
+def _distribute_array_helper(v, array_type=None):
     """
-    Converts (copies) a sequential array/vector on process 0
-    to a distributed PETSc Vec
+    Distributes a numpy array on rank 0 to all ranks using PETSc automatic
+    distribution routine.
 
     Args:
-        v: numpy array on proc 0, None (or whatever) on other proc
+        v: numpy array on rank 0, None (or whatever) on other ranks
+        array_type: set the type of the distributed array
+                    If None, it keeps the same type as v.
 
     Returns:
-        PETSc Vec distributed on all procs
+        numpy array distributed on all procs
+        PETSc.Vec distributed array. All values set to zero.
     """
 
     if MPI_RANK == 0:
         n = len(v)
-        v = v.astype(PETSc.ScalarType)
+        if array_type is None:
+            array_type = v.dtype
+        else:
+            v = v.astype(array_type)
     else:
         n = None
 
-    # Broadcast size
+    # Broadcast size and type
     n = MPI_COMM.bcast(n, root=0)
+    array_type = MPI_COMM.bcast(array_type, root=0)
 
+    # distribute array using PETSc.Vec approach
     x = PETSc.Vec()
     x.create(MPI_COMM)
     x.setSizes(n)
@@ -274,11 +282,48 @@ def array2PETScVec(v):
     if MPI_RANK != 0:
         istart_loc = [0]
 
-    # local vector
-    vloc = np_zeros(nloc, PETSc.ScalarType)
+    # Initialize destination array on each rank
+    vloc = np_zeros(nloc, dtype=array_type)
 
     # scatter the vector v on all ranks
-    MPI_COMM.Scatterv([v, nloc_loc, istart_loc, _from_numpy_dtype(PETSc.ScalarType)], vloc, root=0)
+    MPI_COMM.Scatterv([v, nloc_loc, istart_loc, _from_numpy_dtype(array_type)], vloc, root=0)
+
+    return vloc, x
+
+
+def distribute_array(v, array_type=None):
+    """
+    Distributes a numpy array on rank 0 to all ranks using PETSc automatic
+    distribution routine.
+
+    Args:
+        v: numpy array on rank 0, None (or whatever) on other ranks
+        array_type: set the type of the distributed array
+                    If None, it keeps the same type as v.
+
+    Returns:
+        numpy array distributed on all procs
+    """
+
+    vloc, x = _distribute_array_helper(v, array_type=array_type)
+    x.destroy()  # Free the memory of the PETSc vec
+
+    return vloc
+
+
+def array2PETScVec(v):
+    """
+    Converts (copies) a sequential array/vector on process 0
+    to a distributed PETSc Vec
+
+    Args:
+        v: numpy array on proc 0, None (or whatever) on other proc
+
+    Returns:
+        PETSc Vec distributed on all procs
+    """
+
+    vloc, x = _distribute_array_helper(v, array_type=PETSc.ScalarType)
     x.setArray(vloc)
 
     return x

--- a/astrovascpy/scipy_petsc_conversions.py
+++ b/astrovascpy/scipy_petsc_conversions.py
@@ -248,7 +248,7 @@ def _distribute_array_helper(v, array_type=None):
 
     Returns:
         numpy.array: distributed array on all procs
-        petsc4py.PETSc.Vec: distributed array on all procs. 
+        petsc4py.PETSc.Vec: distributed array on all procs.
                             All entries are initialized to zero.
     """
 
@@ -321,7 +321,7 @@ def array2PETScVec(v):
         v: NumPy array on proc 0, None (or whatever) on other proc
 
     Returns:
-        petsc4py.PETSc.Vec: distributed array on all procs. 
+        petsc4py.PETSc.Vec: distributed array on all procs.
     """
 
     vloc, x = _distribute_array_helper(v, array_type=PETSc.ScalarType)

--- a/examples/compute_static_flow_pressure.py
+++ b/examples/compute_static_flow_pressure.py
@@ -178,7 +178,6 @@ if RAT and graph is not None:
         print("end plotting y and z axes")
 
     if plot_xz:
-
         print("start plotting x and z axes")
         figure = plt.figure(figsize=(15, 15))
         positions = graph.points

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -20,9 +20,11 @@ COMM = MPI.COMM_WORLD
 RANK = COMM.Get_rank()
 
 
-@pytest.mark.mpi(min_size=4)
+@pytest.mark.mpi(min_size=2)
 def test_distribute_array():
-    """Test that a numpy array is distributed correctly among ranks"""
+    """Test that a numpy array is distributed correctly among 4 ranks"""
+
+    assert COMM.Get_size() == 4  # this test only works with 4 ranks
 
     if RANK == 0:
         vec = np.array([-6, -5, -4, -3], dtype=np.int32)
@@ -40,15 +42,15 @@ def test_distribute_array():
 
     vloc = distribute_array(v, array_type=None)
 
-    vec_type = vec.dtype == vloc.dtype  # same type
-    is_equal = np.array_equal(vec, vloc)  # same elements
+    is_same_type = vec.dtype == vloc.dtype  # same type
+    is_same_vec = np.array_equal(vec, vloc)  # same elements
 
-    vec_type_0 = COMM.reduce(vec_type, op=MPI.LAND, root=0)
-    is_equal_0 = COMM.reduce(is_equal, op=MPI.LAND, root=0)
+    is_same_type_0 = COMM.reduce(is_same_type, op=MPI.LAND, root=0)
+    is_same_vec_0 = COMM.reduce(is_same_vec, op=MPI.LAND, root=0)
 
     if RANK == 0:
-        assert vec_type_0 is True
-        assert is_equal_0 is True
+        assert is_same_type_0 is True
+        assert is_same_vec_0 is True
 
 
 @pytest.mark.mpi(min_size=2)


### PR DESCRIPTION
Fix of the issue mentioned in #10 

Replace `BinaryIO2PETScVec` with `distribute_array`. 
`distribute_array` only returns a distributed numpy array. It uses the automatic chunk selection of PETSc.Vec, but it does not set the PETSc.Vec elements. The PETSc.Vec is then deleted.

With this approach we do not copy the array anymore, and we save "type conversion" operations.