### PR TITLE
CI: upload package on Pypi upon tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,17 @@
 include:
 - project: molsys/ci
   file: /ci/pipelines/molsys.bloodflow.yml
+  ref: tristan/publish-pkg
 - project: hpc/gitlab-pipelines
   file: github-project-pipelines.gitlab-ci.yml
 - project: hpc/gitlab-upload-logs
   file: enable-upload.yml
+
+publish-package:
+  needs: [build-wheels]
+  stage: publish
+  script:
+    pip install twine
+    python -m twine upload --username $PYPI_USER --password $PYPI_PASSWORD $PYTHON_PROJECT_DIR/wheelhouse
+  rules:
+  - if: $CI_COMMIT_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,6 @@
 include:
 - project: molsys/ci
   file: /ci/pipelines/molsys.bloodflow.yml
-  ref: tristan/publish-pkg
 - project: hpc/gitlab-pipelines
   file: github-project-pipelines.gitlab-ci.yml
 - project: hpc/gitlab-upload-logs

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     },
     include_package_data=True,
     classifiers=[
-        "Development Status :: Production/Stable",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Education",
         "Intended Audience :: Science/Research",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This change updates the continuous integration process so that it now publishes its release on the official Pypi upon git tag creation. It also fixes an invalid classifier in the project description which were rejected by Pypi.