### PR TITLE
 Lazy import of mpi4py module

### DIFF
--- a/astrovascpy/PetscBinaryIO.py
+++ b/astrovascpy/PetscBinaryIO.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023-2023 Blue Brain Project/EPFL
+Copyright (c) 2023-2024 Blue Brain Project/EPFL
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/astrovascpy/PetscBinaryIO.py
+++ b/astrovascpy/PetscBinaryIO.py
@@ -33,6 +33,7 @@ or
   >>> io.writeBinaryFile('file.dat', [vec,])
 See also PetscBinaryIO.__doc__ and methods therein.
 """
+
 import functools
 import importlib.metadata
 import os
@@ -385,7 +386,7 @@ class PetscBinaryIO(object):
     def writeMatSparse(self, fh, mat):
         """Writes a Mat into a PETSc binary file handle"""
 
-        ((M, N), (I, J, V)) = mat
+        ((M, N), (I, J, V)) = mat  # noqa: E741
         metadata = np.array([MatSparse._classid, M, N, I[-1]], dtype=self._inttype)
         rownz = I[1:] - I[:-1]
 
@@ -427,7 +428,7 @@ class PetscBinaryIO(object):
 
     @decorate_with_conf
     def readMatSciPy(self, fh):
-        (M, N), (I, J, V) = self.readMatSparse(fh)
+        (M, N), (I, J, V) = self.readMatSparse(fh)  # noqa: E741
         return csr_matrix((V, J, I), shape=(M, N))
 
     @decorate_with_conf

--- a/astrovascpy/__init__.py
+++ b/astrovascpy/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023-2023 Blue Brain Project/EPFL
+Copyright (c) 2023-2024 Blue Brain Project/EPFL
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/astrovascpy/bloodflow.py
+++ b/astrovascpy/bloodflow.py
@@ -106,7 +106,7 @@ def update_static_flow_pressure(
             if param not in params:
                 raise BloodFlowError(f"Missing parameter '{param}'")
         blood_viscosity = params["blood_viscosity"]
-        base_pressure = params["p_base"]
+        base_pressure = params["base_pressure"]
 
     if graph is not None:
         entry_flow = input_flow[input_flow > 0]

--- a/astrovascpy/bloodflow.py
+++ b/astrovascpy/bloodflow.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023-2023 Blue Brain Project/EPFL
+Copyright (c) 2023-2024 Blue Brain Project/EPFL
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/astrovascpy/bloodflow.py
+++ b/astrovascpy/bloodflow.py
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import gc
 import logging
 import os
@@ -20,25 +21,27 @@ from functools import partial
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-from mpi4py import MPI as mpi
 from petsc4py import PETSc
 from scipy import sparse
 from scipy.sparse import linalg
 from scipy.stats import randint
 from tqdm import tqdm
 
-from astrovascpy import ou
-from astrovascpy.exceptions import BloodFlowError
-from astrovascpy.scipy_petsc_conversions import PETScVec2array
-from astrovascpy.scipy_petsc_conversions import array2PETScVec
-from astrovascpy.scipy_petsc_conversions import coomatrix2PETScMat
-from astrovascpy.scipy_petsc_conversions import distribute_array
-from astrovascpy.utils import Graph
-from astrovascpy.utils import find_neighbors
-from astrovascpy.utils import mpi_mem
-from astrovascpy.utils import mpi_timer
-
+from . import ou
+from .exceptions import BloodFlowError
+from .scipy_petsc_conversions import PETScVec2array
+from .scipy_petsc_conversions import array2PETScVec
+from .scipy_petsc_conversions import coomatrix2PETScMat
+from .scipy_petsc_conversions import distribute_array
 from .typing import VasculatureParams
+from .utils import Graph
+from .utils import comm
+from .utils import find_neighbors
+from .utils import mpi_mem
+from .utils import mpi_timer
+from .utils import rank
+from .utils import rank0
+from .utils import size
 
 # PETSc is compiled with complex number support
 # -> many warnings from/to PETSc to/from NumPy/SciPy
@@ -46,9 +49,6 @@ warnings.filterwarnings(action="ignore", category=np.ComplexWarning)
 
 print = partial(print, flush=True)
 
-MPI_COMM = mpi.COMM_WORLD
-MPI_RANK = MPI_COMM.Get_rank()
-MPI_SIZE = MPI_COMM.Get_size()
 
 # pylint: disable=protected-access
 
@@ -126,7 +126,7 @@ def update_static_flow_pressure(
         else None
     )
 
-    if MPI_RANK == 0:
+    if rank0():
         cc_mask = graph.cc_mask
         degrees = graph.degrees
         laplacian_cc = laplacian.tocsc()[cc_mask, :][:, cc_mask]
@@ -473,12 +473,12 @@ def simulate_vasodilation_ou_process(graph, dt, nb_iteration, nb_iteration_noise
             kappa_a = None
         print("kappa for arteries: ", kappa_a)
 
-    kappa_c = MPI_COMM.bcast(kappa_c, root=0)
-    sigma_c = MPI_COMM.bcast(sigma_c, root=0)
+    kappa_c = comm().bcast(kappa_c, root=0)
+    sigma_c = comm().bcast(sigma_c, root=0)
     if kappa_c is not None:
         sqrt_kappa_c = np.sqrt(2 * kappa_c)
-    kappa_a = MPI_COMM.bcast(kappa_a, root=0)
-    sigma_a = MPI_COMM.bcast(sigma_a, root=0)
+    kappa_a = comm().bcast(kappa_a, root=0)
+    sigma_a = comm().bcast(sigma_a, root=0)
     if kappa_a is not None:
         sqrt_kappa_a = np.sqrt(2 * kappa_a)
 
@@ -487,8 +487,8 @@ def simulate_vasodilation_ou_process(graph, dt, nb_iteration, nb_iteration_noise
         endfeet_id = graph.edge_properties.loc[:, "endfeet_id"].to_numpy()
 
     # Distribute vectors across MPI ranks
-    radius_origin = distribute_array(radius_origin if MPI_RANK == 0 else None)
-    endfeet_id = distribute_array(endfeet_id if MPI_RANK == 0 else None)
+    radius_origin = distribute_array(radius_origin if rank0() else None)
+    endfeet_id = distribute_array(endfeet_id if rank0() else None)
 
     seed = 1
     for radius_origin_, endfeet_id_ in zip(radius_origin, endfeet_id):
@@ -512,29 +512,29 @@ def simulate_vasodilation_ou_process(graph, dt, nb_iteration, nb_iteration_noise
 
     radii_at_endfeet = np.array(radii_at_endfeet)
     # rae : radii at endfeet
-    rae_rows = MPI_COMM.gather(radii_at_endfeet.shape[0], root=0)
+    rae_rows = comm().gather(radii_at_endfeet.shape[0], root=0)
 
     # if there are zero radii affected by endfeet, return None
     zero_radii = False
-    if MPI_RANK == 0:
+    if rank0():
         if np.sum(rae_rows) == 0:
             zero_radii = True
-    zero_radii = MPI_COMM.bcast(zero_radii, root=0)
+    zero_radii = comm().bcast(zero_radii, root=0)
     if zero_radii:
         return None
 
     rae = np.empty(1)
-    if MPI_RANK == 0:
+    if rank0():
         rae = np.empty((np.sum(rae_rows), radii_at_endfeet.shape[1]), dtype=np.float64)
         rae[: rae_rows[0]] = radii_at_endfeet
 
-    for iproc in range(1, MPI_SIZE):
-        if MPI_RANK == 0:
+    for iproc in range(1, size()):
+        if rank0():
             i0 = np.sum(rae_rows[:iproc])
             i1 = i0 + rae_rows[iproc]
-            MPI_COMM.Recv(rae[i0:i1], source=iproc)
-        elif MPI_RANK == iproc:
-            MPI_COMM.Send(radii_at_endfeet, dest=0)
+            comm().Recv(rae[i0:i1], source=iproc)
+        elif rank() == iproc:
+            comm().Send(radii_at_endfeet, dest=0)
 
     return rae
 
@@ -565,15 +565,16 @@ def simulate_ou_process(
     # nb_iteration_noise = number of time_steps before relaxation starts:
     nb_iteration_noise = round(relaxation_start / time_step)
 
-    # Only MPI_RANK == 0 enters here
+    # Only rank0() enters here
     if graph is not None:
         # create this df to assign radii fast at each iteration
         end_df = graph.edge_properties[["endfeet_id"]]
         end_df = end_df[end_df.endfeet_id != -1]
 
     PETSc.Sys.Print("-> simulate_vasodilation_ou_process")
-    with mpi_timer.region("simulate_vasodilation_ou_process"), mpi_mem.region(
-        "simulate_vasodilation_ou_process"
+    with (
+        mpi_timer.region("simulate_vasodilation_ou_process"),
+        mpi_mem.region("simulate_vasodilation_ou_process"),
     ):
         radii = simulate_vasodilation_ou_process(
             graph, time_step, nb_iteration, nb_iteration_noise, params
@@ -585,7 +586,7 @@ def simulate_ou_process(
         radiii = np.zeros((nb_iteration, graph.n_edges))
 
     time_iterations = range(nb_iteration)
-    if MPI_RANK == 0:
+    if rank0():
         time_iterations = tqdm(range(nb_iteration))
 
     # Compute the edge ids corresponding to input nodes
@@ -669,7 +670,7 @@ def _solve_linear(laplacian, input_flow, params=None):
     MAX_IT = params.get("max_it", 1e3)
     R_TOL = params.get("r_tol", 1e-12)
 
-    if MPI_RANK == 0:
+    if rank0():
         if sparse.issparse(input_flow):
             input_flow = input_flow.toarray()
 
@@ -680,13 +681,14 @@ def _solve_linear(laplacian, input_flow, params=None):
 
     # in os.getenv() the second argument refers to the default value
     if os.getenv("BACKEND_SOLVER_BFS", "scipy") == "scipy":
-        if MPI_RANK == 0 and n_nodes > 2e6:
+        if rank0() and n_nodes > 2e6:
             L.warning(WARNING_MSG, {"n_nodes": n_nodes})
 
-        with mpi_timer.region("Scipy Solver [bloodflow.py]"), mpi_mem.region(
-            "Scipy Solver [bloodflow.py]"
+        with (
+            mpi_timer.region("Scipy Solver [bloodflow.py]"),
+            mpi_mem.region("Scipy Solver [bloodflow.py]"),
         ):
-            if MPI_RANK == 0:
+            if rank0():
                 with warnings.catch_warnings():
                     warnings.filterwarnings("error")
                     try:
@@ -705,26 +707,27 @@ def _solve_linear(laplacian, input_flow, params=None):
                         result = linalg.spsolve(laplacian, input_flow)
 
     if os.getenv("BACKEND_SOLVER_BFS", "scipy") == "scipy":
-        if bool(int(os.getenv("DEBUG_BFS", "0"))) and (MPI_RANK == 0):
+        if bool(int(os.getenv("DEBUG_BFS", "0"))) and (rank0()):
             scipy_res_norm = np.linalg.norm(input_flow - laplacian * result)
             PETSc.Sys.Print(f"-> SciPy residual norm = {scipy_res_norm}")
         return result
 
     # PETSc-related part!
-    if MPI_RANK == 0 and n_nodes < 2e6:
+    if rank0() and n_nodes < 2e6:
         L.warning(WARNING_MSG, {"n_nodes": n_nodes})
 
     # These containers are distributed across MPI tasks, contrary to the SciPy ones!
-    with mpi_timer.region("PETSc containers [bloodflow.py]"), mpi_mem.region(
-        "PETSc containers [bloodflow.py]"
+    with (
+        mpi_timer.region("PETSc containers [bloodflow.py]"),
+        mpi_mem.region("PETSc containers [bloodflow.py]"),
     ):
-        laplacian_petsc = coomatrix2PETScMat(laplacian if MPI_RANK == 0 else [])
-        input_flow_petsc = array2PETScVec(input_flow if MPI_RANK == 0 else [])
-        result_petsc = array2PETScVec(result if MPI_RANK == 0 else [])
+        laplacian_petsc = coomatrix2PETScMat(laplacian if rank0() else [])
+        input_flow_petsc = array2PETScVec(input_flow if rank0() else [])
+        result_petsc = array2PETScVec(result if rank0() else [])
 
         # create the nullspace of the laplacian
-        one_vec = np.ones(shape=len(input_flow)) if MPI_RANK == 0 else None
-        null_vec = array2PETScVec(one_vec if MPI_RANK == 0 else [])
+        one_vec = np.ones(shape=len(input_flow)) if rank0() else None
+        null_vec = array2PETScVec(one_vec if rank0() else [])
         null_space = PETSc.NullSpace().create(null_vec)
         laplacian_petsc.setNullSpace(null_space)
 
@@ -749,24 +752,25 @@ def _solve_linear(laplacian, input_flow, params=None):
     petsc_solver.setFromOptions()
 
     PETSc.Sys.Print("-> PETSc Solver [bloodflow.py] : Start")
-    with mpi_timer.region("PETSc Solver [bloodflow.py]"), mpi_mem.region(
-        "PETSc Solver [bloodflow.py]"
+    with (
+        mpi_timer.region("PETSc Solver [bloodflow.py]"),
+        mpi_mem.region("PETSc Solver [bloodflow.py]"),
     ):
         petsc_solver.solve(input_flow_petsc, result_petsc)
     PETSc.Sys.Print("-> PETSc Solver [bloodflow.py] : End")
 
     # convert to numpy array [only in process 0]
     result_petsc_sp = PETScVec2array(result_petsc)
-    if MPI_RANK == 0:
+    if rank0():
         if laplacian.dtype != PETSc.ScalarType:
             result_petsc_sp = result_petsc_sp.astype(laplacian.dtype)
 
     petsc_res_norm = None
-    if MPI_RANK == 0:
+    if rank0():
         if petsc_solver.getIterationNumber() == petsc_solver.max_it:
             L.warning(f"Reached maximum number of iteration {petsc_solver.max_it}.")
 
-    if bool(int(os.getenv("DEBUG_BFS", "0"))) and MPI_RANK == 0:
+    if bool(int(os.getenv("DEBUG_BFS", "0"))) and rank0():
         petsc_res_norm = np.linalg.norm(input_flow - laplacian * result_petsc_sp)  # l2 norm
         input_flow_norm = np.linalg.norm(input_flow)
         PETSc.Sys.Print("Laplacian matrix size: ", np.shape(laplacian))
@@ -780,7 +784,7 @@ def _solve_linear(laplacian, input_flow, params=None):
             f"-> The KSP preconditioned residual norm is: {petsc_solver.getResidualNorm()}"
         )
 
-    if MPI_RANK == 0:
+    if rank0():
         result = result_petsc_sp
 
     # Clean-up
@@ -788,8 +792,9 @@ def _solve_linear(laplacian, input_flow, params=None):
     # after multiple steps the program crashes with an out-of-memory error!
     # The malloc_trim technique that we use in Neurodamus does not work with PETSc,
     # since it leads to SEG FAULT.
-    with mpi_timer.region("PETSc Mem Clean-Up [bloodflow.py]"), mpi_mem.region(
-        "PETSc Mem Clean-Up [bloodflow.py]"
+    with (
+        mpi_timer.region("PETSc Mem Clean-Up [bloodflow.py]"),
+        mpi_mem.region("PETSc Mem Clean-Up [bloodflow.py]"),
     ):
         petsc_solver.destroy()
         laplacian_petsc.destroy()

--- a/astrovascpy/exceptions.py
+++ b/astrovascpy/exceptions.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023-2023 Blue Brain Project/EPFL
+Copyright (c) 2023-2024 Blue Brain Project/EPFL
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/astrovascpy/io.py
+++ b/astrovascpy/io.py
@@ -10,20 +10,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import os
 import pickle
 from pathlib import Path
 
 import pandas as pd
-from mpi4py import MPI as mpi
 from vascpy import PointVasculature
 from vascpy import SectionVasculature
 
-from astrovascpy.exceptions import BloodFlowError
-from astrovascpy.utils import Graph
-
-MPI_COMM = mpi.COMM_WORLD
-MPI_RANK = MPI_COMM.Get_rank()
+from .exceptions import BloodFlowError
+from .utils import Graph
+from .utils import rank0
 
 
 def load_graph(filename):
@@ -56,7 +54,7 @@ def load_graph_from_bin(filename):
     Returns:
         utils.Graph: graph containing point vasculature skeleton.
     """
-    if MPI_RANK == 0:
+    if rank0():
         if os.path.exists(filename):
             print("Loading graph from binary file using pickle", flush=True)
             filehandler = open(filename, "rb")
@@ -77,7 +75,7 @@ def load_graph_from_h5(filename):
     Returns:
         utils.Graph: graph containing point vasculature skeleton.
     """
-    if MPI_RANK == 0:
+    if rank0():
         if os.path.exists(filename):
             print("Loading sonata graph using PointVasculature.load_sonata", flush=True)
             pv = PointVasculature.load_sonata(filename)
@@ -100,7 +98,7 @@ def load_graph_from_csv(node_filename, edge_filename):
     Returns:
         utils.Graph: graph containing point vasculature skeleton.
     """
-    if MPI_RANK == 0:
+    if rank0():
         print("Loading csv dataset using pandas", flush=True)
         graph_nodes = pd.read_csv(node_filename)
         graph_edges = pd.read_csv(edge_filename)

--- a/astrovascpy/io.py
+++ b/astrovascpy/io.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023-2023 Blue Brain Project/EPFL
+Copyright (c) 2023-2024 Blue Brain Project/EPFL
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/astrovascpy/ou.py
+++ b/astrovascpy/ou.py
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import numpy as np
 import scipy.optimize as scpo
 import scipy.stats as ss

--- a/astrovascpy/plotting.py
+++ b/astrovascpy/plotting.py
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np

--- a/astrovascpy/plotting.py
+++ b/astrovascpy/plotting.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023-2023 Blue Brain Project/EPFL
+Copyright (c) 2023-2024 Blue Brain Project/EPFL
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/astrovascpy/report_reader.py
+++ b/astrovascpy/report_reader.py
@@ -4,7 +4,7 @@ will use snap and will be in archngv most probably.
 Also this is a bit over-engineered but makes things easier if we have different types of reports
 in the future. Plus, this is a light version of the snap classes which will make things easy to
 adapt from these classes to the snap ones.
-Copyright (c) 2023-2023 Blue Brain Project/EPFL
+Copyright (c) 2023-2024 Blue Brain Project/EPFL
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/astrovascpy/report_reader.py
+++ b/astrovascpy/report_reader.py
@@ -15,14 +15,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import numpy as np
 import pandas as pd
 from cached_property import cached_property
 from libsonata import ElementReportReader
 from libsonata import SonataError
 
-from astrovascpy.exceptions import BloodFlowError
-from astrovascpy.utils import ensure_list
+from .exceptions import BloodFlowError
+from .utils import ensure_list
 
 # pylint: disable=missing-kwoa
 

--- a/astrovascpy/report_writer.py
+++ b/astrovascpy/report_writer.py
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 from collections import namedtuple
 from shutil import copyfile
 

--- a/astrovascpy/report_writer.py
+++ b/astrovascpy/report_writer.py
@@ -1,5 +1,5 @@
 """Function to save flows, pressures and radii report in sonata format.
-Copyright (c) 2023-2023 Blue Brain Project/EPFL
+Copyright (c) 2023-2024 Blue Brain Project/EPFL
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/astrovascpy/scipy_petsc_conversions.py
+++ b/astrovascpy/scipy_petsc_conversions.py
@@ -10,29 +10,30 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import os
 import random
 import string
 
-from mpi4py import MPI
 from numpy import concatenate
 from numpy import dtype
 from numpy import zeros as np_zeros
 from petsc4py import PETSc
 from scipy.sparse import csr_matrix
 
-from astrovascpy import PetscBinaryIO
-
-MPI_COMM = MPI.COMM_WORLD
-MPI_RANK = MPI_COMM.Get_rank()
-MPI_SIZE = MPI_COMM.Get_size()
+from . import PetscBinaryIO
+from .utils import comm
+from .utils import mpi
+from .utils import rank
+from .utils import rank0
+from .utils import size
 
 
 def _from_numpy_dtype(np_type):
     """Convert NumPy datatype to MPI datatype."""
     dtype_var = dtype(np_type)
     char_d = dtype_var.char
-    mpi_type = MPI._typedict[char_d]
+    mpi_type = mpi()._typedict[char_d]
     return mpi_type
 
 
@@ -51,9 +52,9 @@ def BinaryIO2PETScMat(L, file_name="tempMat.dat"):
     # when running more than two instances of the program
     fname_ = "".join(random.choices(string.ascii_lowercase, k=10))
     fname_ += f"_{str(id(L))}_" + file_name
-    fname_ = MPI_COMM.bcast(fname_, root=0)
+    fname_ = comm().bcast(fname_, root=0)
 
-    if MPI_RANK == 0:
+    if rank0():
         PetscBinaryIO.PetscBinaryIO().writeBinaryFile(
             fname_,
             [
@@ -62,9 +63,9 @@ def BinaryIO2PETScMat(L, file_name="tempMat.dat"):
         )
 
     viewer = PETSc.Viewer().createBinary(fname_, "r")
-    A = PETSc.Mat(comm=MPI_COMM).load(viewer)
+    A = PETSc.Mat(comm=comm()).load(viewer)
 
-    if MPI_RANK == 0:
+    if rank0():
         os.remove(fname_)
         try:
             os.remove(fname_ + ".info")
@@ -86,9 +87,9 @@ def BinaryIO2PETScVec(v, file_name="tempVec.dat"):
     """
 
     fname_ = "".join(random.choices(string.ascii_lowercase, k=10)) + f"_{str(id(v))}_" + file_name
-    fname_ = MPI_COMM.bcast(fname_, root=0)
+    fname_ = comm().bcast(fname_, root=0)
 
-    if MPI_RANK == 0:
+    if rank0():
         PetscBinaryIO.PetscBinaryIO().writeBinaryFile(
             fname_,
             [
@@ -97,9 +98,9 @@ def BinaryIO2PETScVec(v, file_name="tempVec.dat"):
         )
 
     viewer = PETSc.Viewer().createBinary(fname_, "r")
-    x = PETSc.Vec(comm=MPI_COMM).load(viewer)
+    x = PETSc.Vec(comm=comm()).load(viewer)
 
-    if MPI_RANK == 0:
+    if rank0():
         os.remove(fname_)
         try:
             os.remove(fname_ + ".info")
@@ -120,16 +121,16 @@ def BinaryIO2array(x, file_name="tempVec.dat"):
     """
 
     fname_ = "".join(random.choices(string.ascii_lowercase, k=10)) + f"_{str(id(x))}_" + file_name
-    fname_ = MPI_COMM.bcast(fname_, root=0)
+    fname_ = comm().bcast(fname_, root=0)
 
     viewer = PETSc.Viewer().createBinary(fname_, "w")
     viewer(x)
 
     v = None
-    if MPI_RANK == 0:
+    if rank0():
         (v,) = PetscBinaryIO.PetscBinaryIO().readBinaryFile(fname_)
 
-    if MPI_RANK == 0:
+    if rank0():
         os.remove(fname_)
         try:
             os.remove(fname_ + ".info")
@@ -152,7 +153,7 @@ def coomatrix2PETScMat(L):
     """
 
     # Get the data from the sequential scipy matrix
-    if MPI_RANK == 0:
+    if rank0():
         if L.format == "coo":
             L2 = L
         else:
@@ -182,10 +183,10 @@ def coomatrix2PETScMat(L):
         Ai = None
 
     # Broadcast sizes
-    n = MPI_COMM.bcast(n, root=0)
-    m = MPI_COMM.bcast(m, root=0)
+    n = comm().bcast(n, root=0)
+    m = comm().bcast(m, root=0)
 
-    A = PETSc.Mat().create(comm=MPI_COMM)
+    A = PETSc.Mat().create(comm=comm())
     A.setSizes([n, m])
     A.setType("aij")
     A.setFromOptions()
@@ -195,13 +196,13 @@ def coomatrix2PETScMat(L):
     istart, iend = A.getOwnershipRange()
 
     # gather all ranges in rank 0 (None for the other ranks)
-    istart_loc = MPI_COMM.gather(istart, root=0)
-    iend_loc = MPI_COMM.gather(iend, root=0)
+    istart_loc = comm().gather(istart, root=0)
+    iend_loc = comm().gather(iend, root=0)
 
     nnzloc = None
-    if MPI_RANK == 0:
-        nnzloc_0 = np_zeros(MPI_SIZE, PETSc.IntType)
-        for i in range(MPI_SIZE):
+    if rank0():
+        nnzloc_0 = np_zeros(size(), PETSc.IntType)
+        for i in range(size()):
             # Ai encodes the total number of nonzeros above row istart_loc[i] and iend_loc[i]
             # how many non-zero elements for rank i
             nnzloc_0[i] = Ai[iend_loc[i]] - Ai[istart_loc[i]]
@@ -209,7 +210,7 @@ def coomatrix2PETScMat(L):
         nnzloc_0 = None
 
     # every rank gets the corresponding number (from vector to number)
-    nnzloc = MPI_COMM.scatter(nnzloc_0, root=0)
+    nnzloc = comm().scatter(nnzloc_0, root=0)
 
     # distribute the matrix across ranks (COO format) - create local containers
     row_loc = np_zeros(nnzloc, PETSc.IntType)
@@ -218,13 +219,13 @@ def coomatrix2PETScMat(L):
 
     # For Scatterv
     displ_ = None
-    if MPI_RANK == 0:
+    if rank0():
         displ_ = tuple(concatenate(([0], nnzloc_0[:-1])).cumsum())
 
     # distribute the matrix across ranks (COO format) - populate local containers
-    MPI_COMM.Scatterv([row_, nnzloc_0, displ_, _from_numpy_dtype(PETSc.IntType)], row_loc, root=0)
-    MPI_COMM.Scatterv([col_, nnzloc_0, displ_, _from_numpy_dtype(PETSc.IntType)], col_loc, root=0)
-    MPI_COMM.Scatterv(
+    comm().Scatterv([row_, nnzloc_0, displ_, _from_numpy_dtype(PETSc.IntType)], row_loc, root=0)
+    comm().Scatterv([col_, nnzloc_0, displ_, _from_numpy_dtype(PETSc.IntType)], col_loc, root=0)
+    comm().Scatterv(
         [data_, nnzloc_0, displ_, _from_numpy_dtype(PETSc.ScalarType)], data_loc, root=0
     )
 
@@ -253,7 +254,7 @@ def _distribute_array_helper(v, array_type=None):
                               All entries are initialized to zero.
     """
 
-    if MPI_RANK == 0:
+    if rank0():
         n = len(v)
         if array_type is None:
             array_type = v.dtype
@@ -263,12 +264,12 @@ def _distribute_array_helper(v, array_type=None):
         n = None
 
     # Broadcast size and type
-    n = MPI_COMM.bcast(n, root=0)
-    array_type = MPI_COMM.bcast(array_type, root=0)
+    n = comm().bcast(n, root=0)
+    array_type = comm().bcast(array_type, root=0)
 
     # distribute array using PETSc.Vec approach
     x = PETSc.Vec()
-    x.create(MPI_COMM)
+    x.create(comm())
     x.setSizes(n)
     x.setFromOptions()
     istart, iend = x.getOwnershipRange()
@@ -276,19 +277,19 @@ def _distribute_array_helper(v, array_type=None):
     # slice of the global vector that belongs to this mpi rank (range: from -> to)
     nloc = iend - istart
     # gather nloc on rank zero
-    nloc_loc = MPI_COMM.gather(nloc, root=0)
-    if MPI_RANK != 0:
+    nloc_loc = comm().gather(nloc, root=0)
+    if not rank0():
         nloc_loc = [0]
     # gather istart on rank zero.
-    istart_loc = MPI_COMM.gather(istart, root=0)
-    if MPI_RANK != 0:
+    istart_loc = comm().gather(istart, root=0)
+    if not rank0():
         istart_loc = [0]
 
     # Initialize destination array on each rank
     vloc = np_zeros(nloc, dtype=array_type)
 
     # scatter the vector v on all ranks
-    MPI_COMM.Scatterv([v, nloc_loc, istart_loc, _from_numpy_dtype(array_type)], vloc, root=0)
+    comm().Scatterv([v, nloc_loc, istart_loc, _from_numpy_dtype(array_type)], vloc, root=0)
 
     return vloc, x
 
@@ -331,13 +332,13 @@ def array2PETScVec(v):
     return x
 
 
-def PETScVec2array(x, rank=0):
+def PETScVec2array(x, dest_rank=0):
     """
     Converts (copies) a distributed PETSc Vec to a sequential array on specified rank
 
     Args:
         x: PETSc Vec distributed on all procs
-        rank: rank receiving the numpy array
+        dest_rank: MPI rank receiving the numpy array
 
     Returns:
         NumPy array on proc 0
@@ -349,32 +350,32 @@ def PETScVec2array(x, rank=0):
     istart, iend = x.getOwnershipRange()
 
     nloc = iend - istart
-    nloc_loc = MPI_COMM.gather(nloc, root=rank)
-    if MPI_RANK != rank:
+    nloc_loc = comm().gather(nloc, root=dest_rank)
+    if rank() != dest_rank:
         nloc_loc = [0]
 
-    istart_loc = MPI_COMM.gather(istart, root=rank)
-    if MPI_RANK != rank:
+    istart_loc = comm().gather(istart, root=dest_rank)
+    if rank() != dest_rank:
         istart_loc = [0]
 
-    if MPI_RANK == rank:
+    if rank() == dest_rank:
         v = np_zeros(n, PETSc.ScalarType)
     else:
         v = None
 
-    MPI_COMM.Gatherv(vloc, [v, nloc_loc, istart_loc, _from_numpy_dtype(PETSc.ScalarType)], root=0)
+    comm().Gatherv(vloc, [v, nloc_loc, istart_loc, _from_numpy_dtype(PETSc.ScalarType)], root=0)
 
     return v
 
 
-def PETScMat2coo(A, rank=0):
+def PETScMat2coo(A, dest_rank=0):
     """
     Converts a distributed PETSc sparse matrice to a scipy coo
     sparse matrix on a specified rank
 
     Args:
         A: PETSc Mat distributed on all procs
-        rank: rank receiving the coo sparse matrix
+        dest_rank: MPI rank receiving the coo sparse matrix
 
     Returns:
         scipy coo sparse matrix on the specified rank
@@ -384,11 +385,11 @@ def PETScMat2coo(A, rank=0):
     m, n = A.getSize()
 
     # gatered values
-    iptr_gat = MPI_COMM.gather(indptr_loc, root=rank)
-    ind_gat = MPI_COMM.gather(indices_loc, root=rank)
-    data_gat = MPI_COMM.gather(data_loc, root=rank)
+    iptr_gat = comm().gather(indptr_loc, root=dest_rank)
+    ind_gat = comm().gather(indices_loc, root=dest_rank)
+    data_gat = comm().gather(data_loc, root=dest_rank)
 
-    if MPI_RANK == rank:
+    if rank() == dest_rank:
         data = concatenate(data_gat)
         indices = concatenate(ind_gat)
 

--- a/astrovascpy/scipy_petsc_conversions.py
+++ b/astrovascpy/scipy_petsc_conversions.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023-2023 Blue Brain Project/EPFL
+Copyright (c) 2023-2024 Blue Brain Project/EPFL
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/astrovascpy/typing.py
+++ b/astrovascpy/typing.py
@@ -28,4 +28,4 @@ class VasculatureParams(typing.TypedDict):
     depth_ratio: float
     vasc_axis: VasculatureAxis
     blood_viscosity: float
-    p_base: float
+    base_pressure: float

--- a/astrovascpy/typing.py
+++ b/astrovascpy/typing.py
@@ -1,5 +1,16 @@
 """
 :pep:`484`-style type annotations for the public API of this package
+
+Copyright (c) 2023-2024 Blue Brain Project/EPFL
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 """
 
 import enum

--- a/astrovascpy/utils.py
+++ b/astrovascpy/utils.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023-2023 Blue Brain Project/EPFL
+Copyright (c) 2023-2024 Blue Brain Project/EPFL
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/astrovascpy/version.py
+++ b/astrovascpy/version.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2023-2023 Blue Brain Project/EPFL
+Copyright (c) 2023-2024 Blue Brain Project/EPFL
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/astrovascpy/vtk_io.py
+++ b/astrovascpy/vtk_io.py
@@ -1,6 +1,6 @@
 """
 file taken from https://github.com/eleftherioszisis/VasculatureRepair.
-Copyright (c) 2023-2023 Blue Brain Project/EPFL
+Copyright (c) 2023-2024 Blue Brain Project/EPFL
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/astrovascpy/vtk_io.py
+++ b/astrovascpy/vtk_io.py
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import logging
 
 import numpy as np

--- a/examples/data/params.yaml
+++ b/examples/data/params.yaml
@@ -9,7 +9,7 @@ vasc_axis: 1  # vasculature axis corresponding to x, y, or z. Should be set to 0
 depth_ratio: 0.05  # Depth along the vasc_axis. This is the portion of the vasculature where there are inputs.
 max_nb_inputs: 3 # maximum number of inputs to inject flow/pressure into vasculature. Should be >= 1.
 
-p_base: 1.33e-3  # reference pressure in g * um^{-1} * s^{-2}. At resting state equal to the external pressure
+base_pressure: 1.33e-3  # reference pressure in g * um^{-1} * s^{-2}. At resting state equal to the external pressure
 
 
 ### OU calibration parameters

--- a/tests/test_bloodflow.py
+++ b/tests/test_bloodflow.py
@@ -32,7 +32,7 @@ def edge_properties():
 def params():
     return {
         "blood_viscosity": 0.1,
-        "p_base": 1.33e-3,
+        "base_pressure": 1.33e-3,
         "max_nb_inputs": 3,
         "depth_ratio": 0.05,
         "vasc_axis": 1,

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -14,7 +14,7 @@ L = logging.getLogger(__name__)
 def params():
     return {
         "blood_viscosity": 0.1,
-        "p_base": 1.33e-3,
+        "base_pressure": 1.33e-3,
         "max_nb_inputs": 3,
         "depth_ratio": 0.05,
         "vasc_axis": 1,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,7 +77,7 @@ def test_create_entry_largest_nodes(point_properties, edge_properties, caplog):
                     "depth_ratio": 10,
                     "vasc_axis": 1,
                     "blood_viscosity": 0.1,
-                    "p_base": 1.33e-3,
+                    "base_pressure": 1.33e-3,
                 },
             )
             == np.array([2])
@@ -93,7 +93,7 @@ def test_create_entry_largest_nodes(point_properties, edge_properties, caplog):
                     "depth_ratio": -1,
                     "vasc_axis": 1,
                     "blood_viscosity": 0.1,
-                    "p_base": 1.33e-3,
+                    "base_pressure": 1.33e-3,
                 },
             )
             == np.array([2])


### PR DESCRIPTION
This change prevents mpi4py to call `MPI_Init` under the hood automatically when the `astrovascpy` module is imported.