### PR TITLE
Use ruff utility for static analysis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,27 +17,23 @@ repos:
           stages:
             - commit-msg
           additional_dependencies: ['conventional-changelog-conventionalcommits']
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-  - repo: https://github.com/psf/black
-    rev: 22.6.0
-    hooks:
-      - id: black
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
     hooks:
       - id: codespell
         args: ["-x", ".codespellignorelines"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.3.2
+    hooks:
+      # Run the linter.
+      - id: ruff
+      # Run the formatter.
+      - id: ruff-format
+
   #- repo: https://github.com/PyCQA/pydocstyle
   #  rev: 6.1.1
   #  hooks:
   #    - id: pydocstyle
   #      additional_dependencies: ["toml"]
   #      exclude: 'examples|tests|scripts'
-  - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
-    hooks:
-      - id: flake8
-        exclude: 'examples|tests|scripts'

--- a/astrovascpy/bloodflow.py
+++ b/astrovascpy/bloodflow.py
@@ -29,19 +29,14 @@ from tqdm import tqdm
 
 from . import ou
 from .exceptions import BloodFlowError
-from .scipy_petsc_conversions import PETScVec2array
-from .scipy_petsc_conversions import array2PETScVec
-from .scipy_petsc_conversions import coomatrix2PETScMat
-from .scipy_petsc_conversions import distribute_array
+from .scipy_petsc_conversions import (
+    PETScVec2array,
+    array2PETScVec,
+    coomatrix2PETScMat,
+    distribute_array,
+)
 from .typing import VasculatureParams
-from .utils import Graph
-from .utils import comm
-from .utils import find_neighbors
-from .utils import mpi_mem
-from .utils import mpi_timer
-from .utils import rank
-from .utils import rank0
-from .utils import size
+from .utils import Graph, comm, find_neighbors, mpi_mem, mpi_timer, rank, rank0, size
 
 # PETSc is compiled with complex number support
 # -> many warnings from/to PETSc to/from NumPy/SciPy
@@ -298,9 +293,9 @@ def set_radius_at_endfoot(graph, endfoot_id, endfoot_radius):
     # if (np.asarray(endfoot_radius) <= 0).any():
     #    raise BloodFlowError("Please provide endfoot_radius > 0.")
 
-    graph.edge_properties.loc[
-        graph.edge_properties.endfeet_id == endfoot_id, ["radius"]
-    ] = endfoot_radius
+    graph.edge_properties.loc[graph.edge_properties.endfeet_id == endfoot_id, ["radius"]] = (
+        endfoot_radius
+    )
 
 
 def set_endfoot_id(graph, endfoot_id, section_id, segment_id, endfeet_length):  # pragma: no cover

--- a/astrovascpy/io.py
+++ b/astrovascpy/io.py
@@ -16,12 +16,10 @@ import pickle
 from pathlib import Path
 
 import pandas as pd
-from vascpy import PointVasculature
-from vascpy import SectionVasculature
+from vascpy import PointVasculature, SectionVasculature
 
 from .exceptions import BloodFlowError
-from .utils import Graph
-from .utils import rank0
+from .utils import Graph, rank0
 
 
 def load_graph(filename):

--- a/astrovascpy/report_reader.py
+++ b/astrovascpy/report_reader.py
@@ -19,8 +19,7 @@ limitations under the License.
 import numpy as np
 import pandas as pd
 from cached_property import cached_property
-from libsonata import ElementReportReader
-from libsonata import SonataError
+from libsonata import ElementReportReader, SonataError
 
 from .exceptions import BloodFlowError
 from .utils import ensure_list

--- a/astrovascpy/scipy_petsc_conversions.py
+++ b/astrovascpy/scipy_petsc_conversions.py
@@ -15,18 +15,13 @@ import os
 import random
 import string
 
-from numpy import concatenate
-from numpy import dtype
+from numpy import concatenate, dtype
 from numpy import zeros as np_zeros
 from petsc4py import PETSc
 from scipy.sparse import csr_matrix
 
 from . import PetscBinaryIO
-from .utils import comm
-from .utils import mpi
-from .utils import rank
-from .utils import rank0
-from .utils import size
+from .utils import comm, mpi, rank, rank0, size
 
 
 def _from_numpy_dtype(np_type):

--- a/examples/compute_static_flow_pressure.py
+++ b/examples/compute_static_flow_pressure.py
@@ -12,10 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+
 import sys
 from functools import partial
-from pathlib import Path
-from pathlib import PurePath
+from pathlib import Path, PurePath
 
 import matplotlib.colors as c
 import matplotlib.pyplot as plt
@@ -31,9 +31,7 @@ from astrovascpy.io import load_graph_from_bin
 # from astrovascpy.io import load_graph_from_csv
 # from astrovascpy.io import load_graph_from_h5
 from astrovascpy.report_writer import write_simulation_report
-from astrovascpy.utils import create_entry_largest_nodes
-from astrovascpy.utils import mpi_mem
-from astrovascpy.utils import mpi_timer
+from astrovascpy.utils import create_entry_largest_nodes, mpi_mem, mpi_timer
 
 petsc4py.init(sys.argv)
 

--- a/examples/simulate_OU_process.py
+++ b/examples/simulate_OU_process.py
@@ -11,17 +11,13 @@ import yaml
 from mpi4py import MPI
 from petsc4py import PETSc
 
-from astrovascpy.bloodflow import generate_endfeet
-from astrovascpy.bloodflow import simulate_ou_process
+from astrovascpy.bloodflow import generate_endfeet, simulate_ou_process
 
 # from astrovascpy.io import load_graph_from_bin
 # from astrovascpy.io import load_graph_from_h5
 from astrovascpy.io import load_graph_from_csv
 from astrovascpy.report_writer import write_simulation_report
-from astrovascpy.utils import create_entry_largest_nodes
-from astrovascpy.utils import create_input_speed
-from astrovascpy.utils import mpi_mem
-from astrovascpy.utils import mpi_timer
+from astrovascpy.utils import create_entry_largest_nodes, create_input_speed, mpi_mem, mpi_timer
 
 petsc4py.init(sys.argv)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,62 @@ force_single_line = true
 testpaths = [
     "tests",
 ]
+
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Same as Black.
+line-length = 100
+indent-width = 4
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I"]
+ignore = ["F401", "F403", "F405", "E741", "E721"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 """Setup for the astrovascpy package."""
+
 import importlib.util
 from pathlib import Path
 
-from setuptools import find_namespace_packages
-from setuptools import setup
+from setuptools import find_namespace_packages, setup
 
 spec = importlib.util.spec_from_file_location(
     "astrovascpy.version",

--- a/tests/data/reporting/create_reports.py
+++ b/tests/data/reporting/create_reports.py
@@ -1,4 +1,5 @@
 """Taken from the libsonata lib."""
+
 import h5py
 import numpy as np
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,10 +3,7 @@ from pathlib import Path
 import numpy as np
 import numpy.testing as npt
 
-from astrovascpy.io import load_graph
-from astrovascpy.io import load_graph_from_bin
-from astrovascpy.io import load_graph_from_csv
-from astrovascpy.io import load_graph_from_h5
+from astrovascpy.io import load_graph, load_graph_from_bin, load_graph_from_csv, load_graph_from_h5
 from astrovascpy.PetscBinaryIO import get_conf
 
 TEST_DIR = Path(__file__).resolve().parent

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -5,11 +5,13 @@ import pytest
 from mpi4py import MPI
 from scipy.sparse import coo_matrix
 
-from astrovascpy.scipy_petsc_conversions import PETScMat2coo
-from astrovascpy.scipy_petsc_conversions import PETScVec2array
-from astrovascpy.scipy_petsc_conversions import array2PETScVec
-from astrovascpy.scipy_petsc_conversions import coomatrix2PETScMat
-from astrovascpy.scipy_petsc_conversions import distribute_array
+from astrovascpy.scipy_petsc_conversions import (
+    PETScMat2coo,
+    PETScVec2array,
+    array2PETScVec,
+    coomatrix2PETScMat,
+    distribute_array,
+)
 
 # pip install pytest-mpi
 # mpirun -n 4 pytest --with-mpi tests/test_mpi.py

--- a/tox.ini
+++ b/tox.ini
@@ -46,12 +46,9 @@ allowlist_externals = bash
 deps =
     codespell
     pre-commit
-    pylint
-    pylint-exit
 commands =
     codespell --config .codespellrc -i 3 -x .codespellignorelines -w {[base]files} README.md CHANGELOG.md docs/source
     pre-commit run --all-files --show-diff-on-failure
-    bash -c "pylint -j {env:PYLINT_NPROCS:1} {[base]files} || pylint-exit $?"
 
 [testenv:docs]
 changedir = docs


### PR DESCRIPTION
The command `tox -e lint` now relies on `ruff` utility.
