### PR TITLE
Use pickle in a pandas 2.x compatible way

### DIFF
--- a/astrovascpy/io.py
+++ b/astrovascpy/io.py
@@ -54,7 +54,7 @@ def load_graph_from_bin(filename):
         if os.path.exists(filename):
             print("Loading graph from binary file using pickle", flush=True)
             filehandler = open(filename, "rb")
-            pv = pickle.load(filehandler)
+            pv = pd.read_pickle(filehandler)
             graph = Graph.from_point_vasculature(pv)
         else:
             raise BloodFlowError("Graph file not found")

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ reqs = [
     "mpi4py",
     "networkx",
     "numpy",
-    "pandas<2.0.0",
+    "pandas",
     "psutil",
     "pyyaml",
     "scipy",

--- a/tests/test_bloodflow.py
+++ b/tests/test_bloodflow.py
@@ -424,7 +424,7 @@ def test_total_flow_conservation_in_graph(params):
     TEST_DIR = Path(__file__).resolve().parent.parent
     graph_path_cc = TEST_DIR / "examples/data/graphs_folder/toy_graph.bin"
     filehandler = open(graph_path_cc, "rb")
-    pv = pickle.load(filehandler)
+    pv = pd.read_pickle(filehandler)
     graph = utils.Graph.from_point_vasculature(pv)
 
     entry_nodes = [123, 144, 499]


### PR DESCRIPTION
Going by https://github.com/pandas-dev/pandas/issues/53300 this should
be backwards compatible with older versions of pandas down to 0.20.3.
